### PR TITLE
Add a description & instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ This repository tracks sparse CMS-HGCAL-DQM layouts and rendering plugins for sy
 2. The code will be modified from time to time to meet the needs of beam tests at different stages
 3. The DQM layout for the HGCAL beam tests differs slightly from the official one
 
-Still, once the HGCAL is ready for deployment in the CMS DQM (sometime between 2023 and 2029), one can consider creating a pull request to incorporate the files in the official tool [cms-DQM/dqmgui_prod](https://github.com/cms-DQM/dqmgui_prod).
-
-Below are instructions on building a DQM GUI for the HGCAL (cf. [cms-twiki-DQMGuiForUsers](https://twiki.cern.ch/twiki/bin/viewauth/CMS/DQMGuiForUsers)).
+Below are instructions on building a DQM GUI for the HGCAL. These commands are based on an official tutorial [[1]](https://twiki.cern.ch/twiki/bin/viewauth/CMS/DQMGuiForUsers), with additional steps for setting up HGCAL DQM. The procedure includes the following four steps:
 
 - Step1: Deploy a dqmgui
 - Step2: Update layout and rendering plugins
@@ -16,6 +14,8 @@ Below are instructions on building a DQM GUI for the HGCAL (cf. [cms-twiki-DQMGu
 - Step4: Useful commands (start, stop, and upload DQM files)
 
 Steps 1 to 3 only need to be performed for the first time. Step 4 provides commands for usual maintenance.
+
+Reminder: once the HGCAL is ready for deployment in the CMS DQM (sometime between 2023 and 2029), one can consider creating a pull request to incorporate the files in the official tool [[2]](https://github.com/cms-DQM/dqmgui_prod).
 
 ## How to build a DQM GUI for the HGCAL beam tests
 
@@ -61,7 +61,7 @@ mv backup/HGCalRenderPlugin.cc .
 ```
 
 ### Step3: Implement TH2Poly for monitor elements
-The silicon sensor maps are TH2Poly. These are not yet included in DQMGUI ([cms-sw/cmssw#PR41932](https://github.com/cms-sw/cmssw/pull/41932) and [cms-DQM/dqmgui_prod#PR14](https://github.com/cms-DQM/dqmgui_prod/pull/14)). Use the following commands to implement TH2Poly for displaying polygonal wafer maps. You will need the files from /afs/cern.ch/user/d/ditsiono/public/DQM_stuff
+The silicon sensor maps are TH2Poly. These are not yet included in DQMGUI [3][4]. Use the following commands to implement TH2Poly for displaying polygonal wafer maps. You will need the files from /afs/cern.ch/user/d/ditsiono/public/DQM_stuff
 
 ```bash
 cd ~/tbDQMGUI/current/sw/slc7_amd64_gcc630/cms/dqmgui/
@@ -72,9 +72,7 @@ cp -r </afs/cern.ch/user/d/ditsiono/public/DQM_stuff/new_feature_9.7.8.2/> .
 source quick_replacement.sh
 ```
 
-The `new_feature_9.7.8.2` was created following instructions in [cms-DQM/dqmgui_prod#README.md](https://github.com/cms-DQM/dqmgui_prod/blob/index128/README.md). Relevant links are provided here in case of a need in the future.
-- https://github.com/ywkao/dqmgui_prod/tree/th2poly
-- https://github.com/cms-DQM/dqmgui_prod/issues/13#issuecomment-1576425471
+The `new_feature_9.7.8.2` was created following instructions in [[2]](https://github.com/cms-DQM/dqmgui_prod/blob/index128/README.md). Relevant links are provided here [5][6] in case of a need in the future.
 
 ### Step4: Useful commands (start, stop, and upload DQM files)
 To start the DQM GUI with an "online" flavor:
@@ -110,6 +108,9 @@ source current/apps/dqmgui/128/etc/profile.d/env.sh
 ```
 
 ## Reference
-- https://twiki.cern.ch/twiki/bin/viewauth/CMS/DQMGuiForUsers
-- https://github.com/cms-DQM/dqmgui_prod
-- https://indico.cern.ch/event/1331642/
+[1] https://twiki.cern.ch/twiki/bin/viewauth/CMS/DQMGuiForUsers
+[2] https://github.com/cms-DQM/dqmgui_prod
+[3] [cms-sw/cmssw#PR41932](https://github.com/cms-sw/cmssw/pull/41932)
+[4] [cms-DQM/dqmgui_prod#PR14](https://github.com/cms-DQM/dqmgui_prod/pull/14)
+[5] https://github.com/cms-DQM/dqmgui_prod/issues/13#issuecomment-1576425471
+[6] https://github.com/ywkao/dqmgui_prod/tree/th2poly

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository tracks sparse CMS-HGCAL-DQM layouts and rendering plugins for sy
 2. The code will be modified from time to time to meet the needs of beam tests at different stages
 3. The DQM layout for the HGCAL beam tests differs slightly from the official one
 
-Below are instructions on building a DQM GUI for the HGCAL. These commands are based on an official tutorial [[1]](#1), with additional steps for setting up HGCAL DQM. The procedure includes the following four steps:
+Below are instructions on building a DQM GUI for the HGCAL. These commands are based on an official tutorial, [twiki/CMS/DQMGuiForUsers](https://twiki.cern.ch/twiki/bin/viewauth/CMS/DQMGuiForUsers), with additional steps for setting up HGCAL DQM. The procedure includes the following four steps:
 
 - Step1: Deploy a dqmgui
 - Step2: Update layout and rendering plugins
@@ -15,7 +15,7 @@ Below are instructions on building a DQM GUI for the HGCAL. These commands are b
 
 Steps 1 to 3 only need to be performed for the first time. Step 4 provides commands for usual maintenance.
 
-Reminder: once the HGCAL is ready for deployment in the CMS DQM (sometime between 2023 and 2029), one can consider creating a pull request to incorporate the files in the official tool [[2]](#2).
+Reminder: once the HGCAL is ready for deployment in the CMS DQM (sometime between 2023 and 2029), one can consider creating a pull request to incorporate the files in the official tool [cms-DQM/dqmgui_prod](https://github.com/cms-DQM/dqmgui_prod).
 
 ## How to build a DQM GUI for the HGCAL beam tests
 
@@ -61,7 +61,7 @@ mv backup/HGCalRenderPlugin.cc .
 ```
 
 ### Step3: Implement TH2Poly for monitor elements
-The silicon sensor maps are TH2Poly. These are not yet included in DQMGUI [[3]](#3)[[4]](#4). Use the following commands to implement TH2Poly for displaying polygonal wafer maps. You will need the files from /afs/cern.ch/user/d/ditsiono/public/DQM_stuff
+The silicon sensor maps are TH2Poly. These are not yet included in DQMGUI ([cms-sw/cmssw#PR41932](https://github.com/cms-sw/cmssw/pull/41932), [cms-DQM/dqmgui_prod#PR14](https://github.com/cms-DQM/dqmgui_prod/pull/14)). Use the following commands to implement TH2Poly for displaying polygonal wafer maps. You will need the files from /afs/cern.ch/user/d/ditsiono/public/DQM_stuff
 
 ```bash
 cd ~/tbDQMGUI/current/sw/slc7_amd64_gcc630/cms/dqmgui/
@@ -72,7 +72,9 @@ cp -r </afs/cern.ch/user/d/ditsiono/public/DQM_stuff/new_feature_9.7.8.2/> .
 source quick_replacement.sh
 ```
 
-The `new_feature_9.7.8.2` was created following instructions in [[2]](#2). Relevant links are provided here [[5]](#5)[[6]](#6) in case of a need in the future.
+The `new_feature_9.7.8.2` was created following instructions in [cms-DQM/dqmgui_prod#README.md](https://github.com/cms-DQM/dqmgui_prod/blob/index128/README.md). Relevant links are provided here in case of a need in the future.
+- https://github.com/cms-DQM/dqmgui_prod/issues/13#issuecomment-1576425471
+- https://github.com/ywkao/dqmgui_prod/tree/th2poly
 
 ### Step4: Useful commands (start, stop, and upload DQM files)
 To start the DQM GUI with an "online" flavor:
@@ -107,12 +109,7 @@ General: Every time you log in to the machine, you need to run the following com
 source current/apps/dqmgui/128/etc/profile.d/env.sh
 ```
 
+
 ## Reference
-<ul>
-    <li id="#1">[1] https://twiki.cern.ch/twiki/bin/viewauth/CMS/DQMGuiForUsers</li>
-    <li id="#2">[2] https://github.com/cms-DQM/dqmgui_prod</li>
-    <li id="#3">[3] [cms-sw/cmssw#PR41932](https://github.com/cms-sw/cmssw/pull/41932)</li>
-    <li id="#4">[4] [cms-DQM/dqmgui_prod#PR14](https://github.com/cms-DQM/dqmgui_prod/pull/14)</li>
-    <li id="#5">[5] https://github.com/cms-DQM/dqmgui_prod/issues/13#issuecomment-1576425471</li>
-    <li id="#6">[6] https://github.com/ywkao/dqmgui_prod/tree/th2poly</li>
-</ul>
+- [1] https://twiki.cern.ch/twiki/bin/viewauth/CMS/DQMGuiForUsers
+- [2] https://github.com/cms-DQM/dqmgui_prod

--- a/README.md
+++ b/README.md
@@ -1,1 +1,103 @@
 # hgc-dqmgui
+
+This repository tracks sparse files of CMS-HGCAL-DQM layouts and rendering plugins for system tests. These code are tracked independently because:
+
+1. It is much easier for mainteinance
+2. The code will be modified from time to time to meet the needs in beam tests at different stages
+3. The DQM layout for the HGCAL beam tests can be different from the official one
+4. Expertise from the CMS DQM experts is required to maintain the code in the official tool
+
+Still, once the HGCAL is about to be deployed in the CMS DQM (somtime in the period of 2023 - 2029), one can consider to create a pull request to merge the files in the official tool `dqm-deployment`.
+
+Below shows instructions on building a dqm-gui (cf. [cms-twiki-DQMGuiForUsers](https://twiki.cern.ch/twiki/bin/viewauth/CMS/DQMGuiForUsers)) and replacing the layouts and rendering plugins for the HGCAL beam test purpose.
+
+## Build DQM GUI
+
+Create your DQMGUI directory. Here it is called tbDQMGUI and install the required packages
+```bash
+mkdir tbDQMGUI
+cd tbDQMGUI
+sudo yum -y install git bzip2 perl-Switch perl-Env perl-Thread-Queue libXpm-devel libXmu libXext-devel mesa-libGLU-devel libXinerama libXi libXft-devel libXrandr libXcursor zsh tk perl-ExtUtils-Embed compat-libstdc++-33
+```
+
+In a clean environment do:
+```bash
+/bin/bash
+export PATH=$PATH:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin
+cd tbDQMGUI
+git clone https://github.com/dmwm/deployment.git
+```
+
+Go to https://github.com/dmwm/deployment/tags to get the latest tag. (currently using HGC2306a)
+```bash
+$PWD/deployment/Deploy -A slc7_amd64_gcc630 -r "comp=comp" -R comp@<LATESTTAG> -t MYDEV -s "prep sw post" $PWD dqmgui/bare
+```
+
+Put the files workspaces-online.py, HGCalRenderPlugin.cc and hgcal-layouts.py in the following directories
+```bash
+workspaces-online.py → current/config/dqmgui/
+HGCalRenderPlugin.cc → current/config/dqmgui/style/
+hgcal-layouts.py → current/config/dqmgui/layouts/
+```
+
+We only need HGCAL so we can remove certain files. In style directory keep only utils\* and HGCAL\*
+```bash
+cd current/config/dqmgui/style
+mkdir backup
+mv *.* backup/
+mv backup/utils.* .
+mv backup/HGCalRenderPlugin.cc .
+```
+
+The silicon sensor maps are TH2Poly. These are not yet included in DQMGUI ([cms-sw/cmssw#PR41932](https://github.com/cms-sw/cmssw/pull/41932) and [cms-DQM/dqmgui_prod#PR14](https://github.com/cms-DQM/dqmgui_prod/pull/14)). Follow the next steps in order to be able to display the map plots. You will need the files from /afs/cern.ch/user/d/ditsiono/public/DQM_stuff
+
+```bash
+cd ~/tbDQMGUI/current/sw/slc7_amd64_gcc630/cms/dqmgui/
+cp -r 9.7.8 orig_9.7.8
+
+# Replace the files from the afs directory to your local copy
+cp -r </afs/cern.ch/user/d/ditsiono/public/DQM_stuff/new_feature_9.7.8.2/> .
+cp -r </afs/cern.ch/user/d/ditsiono/public/DQM_stuff/quick.sh> .
+
+source quick.sh
+
+cd 9.7.8/
+cd 128/
+mv include/ tmp
+rm -r tmp/
+cp -r ../../new_feature_9.7.8.2/128/include/ .
+```
+
+To start the DQM GUI with “online” flavor:
+```bash
+cd ~/tbDQMGUI/
+source current/apps/dqmgui/128/etc/profile.d/env.sh
+$PWD/current/config/dqmgui/manage -f online start "I did read documentation"
+```
+
+If you get the error "Unable to perform kinit", please comment block lines related to kerberos in the $PWD/current/config/dqmgui/manage script.
+
+The online flavour listens to port 8070. Once you have started the online GUI you can access it via your browser at:
+```
+http://hgcdaq00.cern.ch:8070/dqm/online-dev/session/
+```
+
+To stop the DQM GUI:
+```bash
+cd ~/tbDQMGUI/
+$PWD/current/config/dqmgui/manage -f online stop "I did read documentation"
+```
+
+To upload a root file:
+```
+visDQMUpload http://hgcdaq00.cern.ch:8070/dqm/online-dev DQM_V0001_HGCAL_R000123481.root
+```
+
+General: After every time you log in to the machine, you need to run the following command in order to have access to DQMGUI commands.
+```
+source current/apps/dqmgui/128/etc/profile.d/env.sh
+```
+
+## Reference
+- https://twiki.cern.ch/twiki/bin/viewauth/CMS/DQMGuiForUsers
+- https://indico.cern.ch/event/1331642/

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # hgc-dqmgui
 
-This repository tracks sparse files of CMS-HGCAL-DQM layouts and rendering plugins for system tests. These code are tracked independently because:
+This repository tracks sparse CMS-HGCAL-DQM layouts and rendering plugins for system tests. These codes are placed in an independent storage instead of the official one because:
 
-1. It is much easier for mainteinance
-2. The code will be modified from time to time to meet the needs in beam tests at different stages
-3. The DQM layout for the HGCAL beam tests can be different from the official one
-4. Expertise from the CMS DQM experts is required to maintain the code in the official tool
+1. Expertise from the CMS DQM experts is required to maintain the code in the official tool
+2. The code will be modified from time to time to meet the needs of beam tests at different stages
+3. The DQM layout for the HGCAL beam tests differs slightly from the official one
 
-Still, once the HGCAL is about to be deployed in the CMS DQM (somtime in the period of 2023 - 2029), one can consider to create a pull request to merge the files in the official tool `dqm-deployment`.
+Still, once the HGCAL is about to be deployed in the CMS DQM (sometime between 2023 and 2029), one can consider creating a pull request to merge the files in the official tool [cms-DQM/dqmgui_prod](https://github.com/cms-DQM/dqmgui_prod).
 
-Below shows instructions on building a dqm-gui (cf. [cms-twiki-DQMGuiForUsers](https://twiki.cern.ch/twiki/bin/viewauth/CMS/DQMGuiForUsers)) and replacing the layouts and rendering plugins for the HGCAL beam test purpose.
+Below are instructions on building a DQM GUI (cf. [cms-twiki-DQMGuiForUsers](https://twiki.cern.ch/twiki/bin/viewauth/CMS/DQMGuiForUsers)) and replacing the codes for the HGCAL beam test purpose.
 
 ## Build DQM GUI
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository tracks sparse CMS-HGCAL-DQM layouts and rendering plugins for sy
 2. The code will be modified from time to time to meet the needs of beam tests at different stages
 3. The DQM layout for the HGCAL beam tests differs slightly from the official one
 
-Below are instructions on building a DQM GUI for the HGCAL. These commands are based on an official tutorial [[1]](https://twiki.cern.ch/twiki/bin/viewauth/CMS/DQMGuiForUsers), with additional steps for setting up HGCAL DQM. The procedure includes the following four steps:
+Below are instructions on building a DQM GUI for the HGCAL. These commands are based on an official tutorial [[1]](#1), with additional steps for setting up HGCAL DQM. The procedure includes the following four steps:
 
 - Step1: Deploy a dqmgui
 - Step2: Update layout and rendering plugins
@@ -15,7 +15,7 @@ Below are instructions on building a DQM GUI for the HGCAL. These commands are b
 
 Steps 1 to 3 only need to be performed for the first time. Step 4 provides commands for usual maintenance.
 
-Reminder: once the HGCAL is ready for deployment in the CMS DQM (sometime between 2023 and 2029), one can consider creating a pull request to incorporate the files in the official tool [[2]](https://github.com/cms-DQM/dqmgui_prod).
+Reminder: once the HGCAL is ready for deployment in the CMS DQM (sometime between 2023 and 2029), one can consider creating a pull request to incorporate the files in the official tool [[2]](#2).
 
 ## How to build a DQM GUI for the HGCAL beam tests
 
@@ -61,7 +61,7 @@ mv backup/HGCalRenderPlugin.cc .
 ```
 
 ### Step3: Implement TH2Poly for monitor elements
-The silicon sensor maps are TH2Poly. These are not yet included in DQMGUI [3][4]. Use the following commands to implement TH2Poly for displaying polygonal wafer maps. You will need the files from /afs/cern.ch/user/d/ditsiono/public/DQM_stuff
+The silicon sensor maps are TH2Poly. These are not yet included in DQMGUI [[3]](#3)[[4]](#4). Use the following commands to implement TH2Poly for displaying polygonal wafer maps. You will need the files from /afs/cern.ch/user/d/ditsiono/public/DQM_stuff
 
 ```bash
 cd ~/tbDQMGUI/current/sw/slc7_amd64_gcc630/cms/dqmgui/
@@ -72,7 +72,7 @@ cp -r </afs/cern.ch/user/d/ditsiono/public/DQM_stuff/new_feature_9.7.8.2/> .
 source quick_replacement.sh
 ```
 
-The `new_feature_9.7.8.2` was created following instructions in [[2]](https://github.com/cms-DQM/dqmgui_prod/blob/index128/README.md). Relevant links are provided here [5][6] in case of a need in the future.
+The `new_feature_9.7.8.2` was created following instructions in [[2]](#2). Relevant links are provided here [[5]](#5)[[6]](#6) in case of a need in the future.
 
 ### Step4: Useful commands (start, stop, and upload DQM files)
 To start the DQM GUI with an "online" flavor:
@@ -108,9 +108,11 @@ source current/apps/dqmgui/128/etc/profile.d/env.sh
 ```
 
 ## Reference
-[1] https://twiki.cern.ch/twiki/bin/viewauth/CMS/DQMGuiForUsers
-[2] https://github.com/cms-DQM/dqmgui_prod
-[3] [cms-sw/cmssw#PR41932](https://github.com/cms-sw/cmssw/pull/41932)
-[4] [cms-DQM/dqmgui_prod#PR14](https://github.com/cms-DQM/dqmgui_prod/pull/14)
-[5] https://github.com/cms-DQM/dqmgui_prod/issues/13#issuecomment-1576425471
-[6] https://github.com/ywkao/dqmgui_prod/tree/th2poly
+<ul>
+    <li id="#1">[1] https://twiki.cern.ch/twiki/bin/viewauth/CMS/DQMGuiForUsers</li>
+    <li id="#2">[2] https://github.com/cms-DQM/dqmgui_prod</li>
+    <li id="#3">[3] [cms-sw/cmssw#PR41932](https://github.com/cms-sw/cmssw/pull/41932)</li>
+    <li id="#4">[4] [cms-DQM/dqmgui_prod#PR14](https://github.com/cms-DQM/dqmgui_prod/pull/14)</li>
+    <li id="#5">[5] https://github.com/cms-DQM/dqmgui_prod/issues/13#issuecomment-1576425471</li>
+    <li id="#6">[6] https://github.com/ywkao/dqmgui_prod/tree/th2poly</li>
+</ul>

--- a/quick_replacement.sh
+++ b/quick_replacement.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# script to be executed under current/sw/slc7_amd64_gcc630/cms/dqmgui/
+
+dir="9.7.8"
+ori_dir="original_9.7.8"
+new_dir="new_feature_9.7.8.2"
+
+function copy()
+{
+    file=$1
+    echo "cp ${new_dir}/${file} ${dir}/${file}"
+    cp ${new_dir}/${file} ${dir}/${file}
+}
+
+function copy_dir()
+{
+    file=$1
+    echo "cp -r ${new_dir}/${file} ${dir}/${file}"
+    cp -r ${new_dir}/${file} ${dir}/${file}
+}
+
+# backup original directory first
+echo "cp -r $dir $ori_dir"
+cp -r $dir $ori_dir
+
+# update files for implementing TH2Poly
+copy 128/bin/DQMCollector
+copy 128/bin/visDQMIndex
+copy 128/bin/visDQMRender
+copy 128/lib/python2.7/site-packages/Monitoring/DQM/Accelerator.so
+copy 128/lib/libDQMGUI.so
+
+# replace the include directory
+echo "mv ${dir}/128/include ${dir}/128/tmp"
+mv ${dir}/128/include ${dir}/128/tmp
+copy_dir 128/include
+
+echo ">>> finished!"


### PR DESCRIPTION
A description of the repository is provided in README.md. Instructions are transferred from the Google document, TestBeam2023_DPG, with reference and relevant links included. A shell script for an efficient file replacement is also tracked.

Remaining files to be tracked / uploaded from `hgcdaq00` machine:
- current/config/dqmgui/workspaces-online.py
- current/config/dqmgui/layouts/hgcal-layouts.py